### PR TITLE
Fix podspec

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-fetch-blob",
-  "version": "0.10.15",
+  "version": "0.10.16",
   "description": "A module provides upload, download, and files access API. Supports file stream read/write for process large files.",
   "main": "index.js",
   "scripts": {

--- a/rn-fetch-blob.podspec
+++ b/rn-fetch-blob.podspec
@@ -9,5 +9,5 @@ Pod::Spec.new do |s|
   s.author       = 'Joltup'
   s.source_files = 'ios/**/*.{h,m}'
   s.platform     = :ios, "8.0"
-  s.dependency 'React/Core'
+  s.dependency 'React'
 end


### PR DESCRIPTION
Using `React/Core` doesn't seem to be compatible with react 0.60.0, changed to just `React`